### PR TITLE
fixes #28 Added preresolved routerpoints to extensions

### DIFF
--- a/src/Itinero.Optimization/Models/Mapping/MappedModel.cs
+++ b/src/Itinero.Optimization/Models/Mapping/MappedModel.cs
@@ -71,7 +71,7 @@ namespace Itinero.Optimization.Models.Mapping
                 WeightMatrixAlgorithm weightMatrixAlgorithm;
                 if (this.Model.Locations != null)
                 {
-                    weightMatrixAlgorithm = new WeightMatrixAlgorithm(_router, profile, this.Model.Locations);
+                    weightMatrixAlgorithm = new WeightMatrixAlgorithm(_router, profile, this.Model.Visits, this.Model.Locations);
                 }
                 else
                 {
@@ -88,7 +88,7 @@ namespace Itinero.Optimization.Models.Mapping
                 DirectedWeightMatrixAlgorithm weightMatrixAlgorithm;
                 if (this.Model.Locations != null)
                 {
-                    weightMatrixAlgorithm = new DirectedWeightMatrixAlgorithm(_router, profile, this.Model.Locations);
+                    weightMatrixAlgorithm = new DirectedWeightMatrixAlgorithm(_router, profile, this.Model.Visits, this.Model.Locations);
                 }
                 else
                 {

--- a/src/Itinero.Optimization/Models/Mapping/MappedModel.cs
+++ b/src/Itinero.Optimization/Models/Mapping/MappedModel.cs
@@ -68,18 +68,34 @@ namespace Itinero.Optimization.Models.Mapping
             _weightMatrix = null;
             if (this.Model.VehiclePool.Vehicles[0].TurnPentalty == 0)
             {
-                var weightMatrixAlgorithm = new WeightMatrixAlgorithm(_router, profile, 
-                    new MassResolvingAlgorithm(_router, new Profiles.IProfileInstance[] { profile }, 
-                        this.Model.Visits));
+                WeightMatrixAlgorithm weightMatrixAlgorithm;
+                if (this.Model.Locations != null)
+                {
+                    weightMatrixAlgorithm = new WeightMatrixAlgorithm(_router, profile, this.Model.Locations);
+                }
+                else
+                {
+                    weightMatrixAlgorithm = new WeightMatrixAlgorithm(_router, profile,
+                        new MassResolvingAlgorithm(_router, new Profiles.IProfileInstance[] { profile },
+                            this.Model.Visits));
+                }
                 weightMatrixAlgorithm.Run();
 
                 _weightMatrix = new WeightMatrix(weightMatrixAlgorithm);
             }
             else
             {
-                var weightMatrixAlgorithm = new DirectedWeightMatrixAlgorithm(_router, profile, 
-                    new MassResolvingAlgorithm(_router, new Profiles.IProfileInstance[] { profile }, 
-                        this.Model.Visits));
+                DirectedWeightMatrixAlgorithm weightMatrixAlgorithm;
+                if (this.Model.Locations != null)
+                {
+                    weightMatrixAlgorithm = new DirectedWeightMatrixAlgorithm(_router, profile, this.Model.Locations);
+                }
+                else
+                {
+                    weightMatrixAlgorithm = new DirectedWeightMatrixAlgorithm(_router, profile,
+                        new MassResolvingAlgorithm(_router, new Profiles.IProfileInstance[] { profile },
+                           this.Model.Visits));
+                }
                 weightMatrixAlgorithm.Run();
                 
                 _weightMatrix = new WeightMatrixDirected(weightMatrixAlgorithm);

--- a/src/Itinero.Optimization/Models/Model.cs
+++ b/src/Itinero.Optimization/Models/Model.cs
@@ -20,6 +20,7 @@ using Itinero.LocalGeo;
 using Itinero.Optimization.Models.Costs;
 using Itinero.Optimization.Models.TimeWindows;
 using Itinero.Optimization.Models.Vehicles;
+using System.Collections.Generic;
 
 namespace Itinero.Optimization.Models
 {
@@ -33,6 +34,12 @@ namespace Itinero.Optimization.Models
         /// </summary>
         /// <returns></returns>
         public Coordinate[] Visits { get; set; }
+
+        /// <summary>
+        /// Gets or sets the resolved locations
+        /// </summary>
+        /// <returns></returns>
+        public List<RouterPoint> Locations { get; set; }
 
         /// <summary>
         /// Gets or sets the time windows.

--- a/src/Itinero.Optimization/RouterExtensions.cs
+++ b/src/Itinero.Optimization/RouterExtensions.cs
@@ -63,17 +63,17 @@ namespace Itinero.Optimization
         /// <summary>
         /// Calculates a directed sequence of the given sequence of locations.
         /// </summary>
-        public static Route CalculateDirected(this RouterBase router, Profile profile, List<RouterPoint> locations, float turnPenaltyInSeconds, Tour sequence)
+        public static Route CalculateDirected(this RouterBase router, Profile profile, Coordinate[] locations, List<RouterPoint> resolvedLocations, float turnPenaltyInSeconds, Tour sequence)
         {
-            return router.TryCalculateDirected(profile, locations, turnPenaltyInSeconds, sequence).Value;
+            return router.TryCalculateDirected(profile, locations, resolvedLocations, turnPenaltyInSeconds, sequence).Value;
         }
 
         /// <summary>
         /// Calculates a directed sequence of the given sequence of locations.
         /// </summary>
-        public static Result<Route> TryCalculateDirected(this RouterBase router, Profile profile, List<RouterPoint> locations, float turnPenaltyInSeconds, Tour sequence)
+        public static Result<Route> TryCalculateDirected(this RouterBase router, Profile profile, Coordinate[] locations, List<RouterPoint> resolvedLocations, float turnPenaltyInSeconds, Tour sequence)
         {
-            var directedRouter = new SequenceDirectedRouter(new DirectedWeightMatrixAlgorithm(router, profile, locations), turnPenaltyInSeconds, sequence);
+            var directedRouter = new SequenceDirectedRouter(new DirectedWeightMatrixAlgorithm(router, profile, locations, resolvedLocations), turnPenaltyInSeconds, sequence);
             directedRouter.Run();
             if (!directedRouter.HasSucceeded)
             {
@@ -93,18 +93,13 @@ namespace Itinero.Optimization
         /// <summary>
         /// Calculates TSP.
         /// </summary>
-        public static Result<Route> TryCalculateTSP(this RouterBase router, Profile profile, List<RouterPoint> locations, int first = 0, int? last = null)
-        {
-            return router.TryCalculateTSP(profile, null, locations, first, last);
-        }
-
-        static Result<Route> TryCalculateTSP(this RouterBase router, Profile profile, Coordinate[] visits, List<RouterPoint> locations, int first, int? last)
+        public static Result<Route> TryCalculateTSP(this RouterBase router, Profile profile, Coordinate[] locations, List<RouterPoint> resolvedLocations, int first = 0, int? last = null)
         {
             // build model.
             var model = new Model()
             {
-                Visits = visits,
-                Locations = locations,
+                Visits = locations,
+                Locations = resolvedLocations,
                 VehiclePool = new Models.Vehicles.VehiclePool()
                 {
                     Vehicles = new Models.Vehicles.Vehicle[]
@@ -137,9 +132,9 @@ namespace Itinero.Optimization
         /// <summary>
         /// Calculates TSP.
         /// </summary>
-        public static Route CalculateTSP(this RouterBase router, Profile profile, List<RouterPoint> locations, int first = 0, int? last = null)
+        public static Route CalculateTSP(this RouterBase router, Profile profile, Coordinate[] locations, List<RouterPoint> resolvedLocations, int first = 0, int? last = null)
         {
-            return router.TryCalculateTSP(profile, locations, first, last).Value;
+            return router.TryCalculateTSP(profile, locations, resolvedLocations, first, last).Value;
         }
 
         /// <summary>
@@ -153,18 +148,13 @@ namespace Itinero.Optimization
         /// <summary>
         /// Calculates TSP.
         /// </summary>
-        public static Result<Route> TryCalculateTSPDirected(this Router router, Profile profile, List<RouterPoint> locations, float turnPenaltyInSeconds, int first = 0, int? last = null)
-        {
-            return router.TryCalculateTSPDirected(profile, null, locations, turnPenaltyInSeconds, first, last);
-        }
-
-        static Result<Route> TryCalculateTSPDirected(this Router router, Profile profile, Coordinate[] visits, List<RouterPoint> locations, float turnPenaltyInSeconds, int first, int? last)
+        public static Result<Route> TryCalculateTSPDirected(this Router router, Profile profile, Coordinate[] locations, List<RouterPoint> resolvedLocations, float turnPenaltyInSeconds, int first = 0, int? last = null)
         {
             // build model.
             var model = new Model()
             {
-                Visits = visits,
-                Locations = locations,
+                Visits = locations,
+                Locations = resolvedLocations,
                 VehiclePool = new Models.Vehicles.VehiclePool()
                 {
                     Vehicles = new Models.Vehicles.Vehicle[] 
@@ -198,6 +188,14 @@ namespace Itinero.Optimization
         /// <summary>
         /// Calculates TSP.
         /// </summary>
+        public static Route CalculateTSPDirected(this Router router, Profile profile, Coordinate[] locations, List<RouterPoint> resolvedLocations, float turnPenaltyInSeconds, int first = 0, int? last = null)
+        {
+            return router.TryCalculateTSPDirected(profile, locations, resolvedLocations, turnPenaltyInSeconds, first, last).Value;
+        }
+
+        /// <summary>
+        /// Calculates TSP.
+        /// </summary>
         public static Result<Route> TryCalculateTSPTW(this RouterBase router, Profile profile, Coordinate[] locations, TimeWindow[] windows, int first = 0, int? last = null)
         {
             return router.TryCalculateTSPTW(profile, locations, null, windows, first, last);
@@ -206,18 +204,13 @@ namespace Itinero.Optimization
         /// <summary>
         /// Calculates TSP.
         /// </summary>
-        public static Result<Route> TryCalculateTSPTW(this RouterBase router, Profile profile, List<RouterPoint> locations, TimeWindow[] windows, int first = 0, int? last = null)
-        {
-            return router.TryCalculateTSPTW(profile, null, locations, windows, first, last);
-        }
-
-        static Result<Route> TryCalculateTSPTW(this RouterBase router, Profile profile, Coordinate[] visits, List<RouterPoint> locations, TimeWindow[] windows, int first, int? last)
+        public static Result<Route> TryCalculateTSPTW(this RouterBase router, Profile profile, Coordinate[] locations, List<RouterPoint> resolvedLocations, TimeWindow[] windows, int first = 0, int? last = null)
         {
             // build model.
             var model = new Model()
             {
-                Visits = visits,
-                Locations = locations,
+                Visits = locations,
+                Locations = resolvedLocations,
                 VehiclePool = new Models.Vehicles.VehiclePool()
                 {
                     Vehicles = new Models.Vehicles.Vehicle[] 
@@ -259,18 +252,13 @@ namespace Itinero.Optimization
         /// <summary>
         /// Calculates TSP.
         /// </summary>
-        public static Result<Route> TryCalculateTSPTWDirected(this Router router, Profile profile, List<RouterPoint> locations, TimeWindow[] windows, float turnPenaltyInSeconds, int first = 0, int? last = null)
-        {
-            return router.TryCalculateTSPTWDirected(profile, null, locations, windows, turnPenaltyInSeconds, first, last);
-        }
-
-        static Result<Route> TryCalculateTSPTWDirected(this Router router, Profile profile, Coordinate[] visits, List<RouterPoint> locations, TimeWindow[] windows, float turnPenaltyInSeconds, int first, int? last)
+        public static Result<Route> TryCalculateTSPTWDirected(this Router router, Profile profile, Coordinate[] locations, List<RouterPoint> resolvedLocations, TimeWindow[] windows, float turnPenaltyInSeconds, int first = 0, int? last = null)
         {
             // build model.
             var model = new Model()
             {
-                Visits = visits,
-                Locations = locations,
+                Visits = locations,
+                Locations = resolvedLocations,
                 VehiclePool = new Models.Vehicles.VehiclePool()
                 {
                     Vehicles = new Models.Vehicles.Vehicle[] 
@@ -313,18 +301,13 @@ namespace Itinero.Optimization
         /// <summary>
         /// Calculates STSP.
         /// </summary>
-        public static Result<Route> TryCalculateSTSP(this RouterBase router, Profile profile, List<RouterPoint> locations, float max, int first = 0, int? last = null)
-        {
-            return router.TryCalculateSTSP(profile, null, locations, max, first, last);
-        }
-
-        static Result<Route> TryCalculateSTSP(this RouterBase router, Profile profile, Coordinate[] visits, List<RouterPoint> locations, float max, int first, int? last)
+        public static Result<Route> TryCalculateSTSP(this RouterBase router, Profile profile, Coordinate[] locations, List<RouterPoint> resolvedLocations, float max, int first = 0, int? last = null)
         {
             // build model.
             var model = new Model()
             {
-                Visits = visits,
-                Locations = locations,
+                Visits = locations,
+                Locations = resolvedLocations,
                 VehiclePool = new Models.Vehicles.VehiclePool()
                 {
                     Vehicles = new Models.Vehicles.Vehicle[] 
@@ -365,9 +348,9 @@ namespace Itinero.Optimization
         /// <summary>
         /// Calculates STSP.
         /// </summary>
-        public static Route CalculateSTSP(this RouterBase router, Profile profile, List<RouterPoint> locations, float max, int first = 0, int? last = null)
+        public static Route CalculateSTSP(this RouterBase router, Profile profile, Coordinate[] locations, List<RouterPoint> resolvedLocations, float max, int first = 0, int? last = null)
         {
-            return router.TryCalculateSTSP(profile, locations, max, first, last).Value;
+            return router.TryCalculateSTSP(profile, locations, resolvedLocations, max, first, last).Value;
         }
 
         /// <summary>
@@ -381,18 +364,13 @@ namespace Itinero.Optimization
         /// <summary>
         /// Calculates STSP.
         /// </summary>
-        public static Result<Route> TryCalculateSTSPDirected(this Router router, Profile profile, List<RouterPoint> locations, float turnPenaltyInSeconds, float max, int first = 0, int? last = null)
-        {
-            return router.TryCalculateSTSPDirected(profile, null, locations, turnPenaltyInSeconds, max, first, last);
-        }
-
-        static Result<Route> TryCalculateSTSPDirected(this Router router, Profile profile, Coordinate[] visits, List<RouterPoint> locations, float turnPenaltyInSeconds, float max, int first, int? last)
+        public static Result<Route> TryCalculateSTSPDirected(this Router router, Profile profile, Coordinate[] locations, List<RouterPoint> resolvedLocations, float turnPenaltyInSeconds, float max, int first = 0, int? last = null)
         {
             // build model.
             var model = new Model()
             {
-                Visits = visits,
-                Locations = locations,
+                Visits = locations,
+                Locations = resolvedLocations,
                 VehiclePool = new Models.Vehicles.VehiclePool()
                 {
                     Vehicles = new Models.Vehicles.Vehicle[] 
@@ -434,9 +412,9 @@ namespace Itinero.Optimization
         /// <summary>
         /// Calculates STSP.
         /// </summary>
-        public static Route CalculateSTSPDirected(this Router router, Profile profile, List<RouterPoint> locations, float turnPenaltyInSeconds, float max, int first = 0, int? last = null)
+        public static Route CalculateSTSPDirected(this Router router, Profile profile, Coordinate[] locations, List<RouterPoint> resolvedLocations, float turnPenaltyInSeconds, float max, int first = 0, int? last = null)
         {
-            return router.TryCalculateSTSPDirected(profile, locations, turnPenaltyInSeconds, max, first, last).Value;
+            return router.TryCalculateSTSPDirected(profile, locations, resolvedLocations, turnPenaltyInSeconds, max, first, last).Value;
         }
 
         /// <summary>

--- a/src/Itinero.Optimization/RouterExtensions.cs
+++ b/src/Itinero.Optimization/RouterExtensions.cs
@@ -61,17 +61,53 @@ namespace Itinero.Optimization
         }
 
         /// <summary>
+        /// Calculates a directed sequence of the given sequence of locations.
+        /// </summary>
+        public static Route CalculateDirected(this RouterBase router, Profile profile, List<RouterPoint> locations, float turnPenaltyInSeconds, Tour sequence)
+        {
+            return router.TryCalculateDirected(profile, locations, turnPenaltyInSeconds, sequence).Value;
+        }
+
+        /// <summary>
+        /// Calculates a directed sequence of the given sequence of locations.
+        /// </summary>
+        public static Result<Route> TryCalculateDirected(this RouterBase router, Profile profile, List<RouterPoint> locations, float turnPenaltyInSeconds, Tour sequence)
+        {
+            var directedRouter = new SequenceDirectedRouter(new DirectedWeightMatrixAlgorithm(router, profile, locations), turnPenaltyInSeconds, sequence);
+            directedRouter.Run();
+            if (!directedRouter.HasSucceeded)
+            {
+                return new Result<Route>(directedRouter.ErrorMessage);
+            }
+            return new Result<Route>(directedRouter.WeightMatrix.BuildRoute(directedRouter.Tour));
+        }
+
+        /// <summary>
         /// Calculates TSP.
         /// </summary>
         public static Result<Route> TryCalculateTSP(this RouterBase router, Profile profile, Coordinate[] locations, int first = 0, int? last = null)
         {
+            return router.TryCalculateTSP(profile, locations, null, first, last);
+        }
+
+        /// <summary>
+        /// Calculates TSP.
+        /// </summary>
+        public static Result<Route> TryCalculateTSP(this RouterBase router, Profile profile, List<RouterPoint> locations, int first = 0, int? last = null)
+        {
+            return router.TryCalculateTSP(profile, null, locations, first, last);
+        }
+
+        static Result<Route> TryCalculateTSP(this RouterBase router, Profile profile, Coordinate[] visits, List<RouterPoint> locations, int first, int? last)
+        {
             // build model.
             var model = new Model()
             {
-                Visits = locations,
+                Visits = visits,
+                Locations = locations,
                 VehiclePool = new Models.Vehicles.VehiclePool()
                 {
-                    Vehicles = new Models.Vehicles.Vehicle[] 
+                    Vehicles = new Models.Vehicles.Vehicle[]
                     {
                         new Models.Vehicles.Vehicle()
                         {
@@ -101,12 +137,34 @@ namespace Itinero.Optimization
         /// <summary>
         /// Calculates TSP.
         /// </summary>
+        public static Route CalculateTSP(this RouterBase router, Profile profile, List<RouterPoint> locations, int first = 0, int? last = null)
+        {
+            return router.TryCalculateTSP(profile, locations, first, last).Value;
+        }
+
+        /// <summary>
+        /// Calculates TSP.
+        /// </summary>
         public static Result<Route> TryCalculateTSPDirected(this Router router, Profile profile, Coordinate[] locations, float turnPenaltyInSeconds, int first = 0, int? last = null)
+        {
+            return router.TryCalculateTSPDirected(profile, locations, null, turnPenaltyInSeconds, first, last);
+        }
+
+        /// <summary>
+        /// Calculates TSP.
+        /// </summary>
+        public static Result<Route> TryCalculateTSPDirected(this Router router, Profile profile, List<RouterPoint> locations, float turnPenaltyInSeconds, int first = 0, int? last = null)
+        {
+            return router.TryCalculateTSPDirected(profile, null, locations, turnPenaltyInSeconds, first, last);
+        }
+
+        static Result<Route> TryCalculateTSPDirected(this Router router, Profile profile, Coordinate[] visits, List<RouterPoint> locations, float turnPenaltyInSeconds, int first, int? last)
         {
             // build model.
             var model = new Model()
             {
-                Visits = locations,
+                Visits = visits,
+                Locations = locations,
                 VehiclePool = new Models.Vehicles.VehiclePool()
                 {
                     Vehicles = new Models.Vehicles.Vehicle[] 
@@ -142,10 +200,24 @@ namespace Itinero.Optimization
         /// </summary>
         public static Result<Route> TryCalculateTSPTW(this RouterBase router, Profile profile, Coordinate[] locations, TimeWindow[] windows, int first = 0, int? last = null)
         {
+            return router.TryCalculateTSPTW(profile, locations, null, windows, first, last);
+        }
+
+        /// <summary>
+        /// Calculates TSP.
+        /// </summary>
+        public static Result<Route> TryCalculateTSPTW(this RouterBase router, Profile profile, List<RouterPoint> locations, TimeWindow[] windows, int first = 0, int? last = null)
+        {
+            return router.TryCalculateTSPTW(profile, null, locations, windows, first, last);
+        }
+
+        static Result<Route> TryCalculateTSPTW(this RouterBase router, Profile profile, Coordinate[] visits, List<RouterPoint> locations, TimeWindow[] windows, int first, int? last)
+        {
             // build model.
             var model = new Model()
             {
-                Visits = locations,
+                Visits = visits,
+                Locations = locations,
                 VehiclePool = new Models.Vehicles.VehiclePool()
                 {
                     Vehicles = new Models.Vehicles.Vehicle[] 
@@ -181,10 +253,24 @@ namespace Itinero.Optimization
         /// </summary>
         public static Result<Route> TryCalculateTSPTWDirected(this Router router, Profile profile, Coordinate[] locations, TimeWindow[] windows, float turnPenaltyInSeconds, int first = 0, int? last = null)
         {
+            return router.TryCalculateTSPTWDirected(profile, locations, null, windows, turnPenaltyInSeconds, first, last);
+        }
+
+        /// <summary>
+        /// Calculates TSP.
+        /// </summary>
+        public static Result<Route> TryCalculateTSPTWDirected(this Router router, Profile profile, List<RouterPoint> locations, TimeWindow[] windows, float turnPenaltyInSeconds, int first = 0, int? last = null)
+        {
+            return router.TryCalculateTSPTWDirected(profile, null, locations, windows, turnPenaltyInSeconds, first, last);
+        }
+
+        static Result<Route> TryCalculateTSPTWDirected(this Router router, Profile profile, Coordinate[] visits, List<RouterPoint> locations, TimeWindow[] windows, float turnPenaltyInSeconds, int first, int? last)
+        {
             // build model.
             var model = new Model()
             {
-                Visits = locations,
+                Visits = visits,
+                Locations = locations,
                 VehiclePool = new Models.Vehicles.VehiclePool()
                 {
                     Vehicles = new Models.Vehicles.Vehicle[] 
@@ -221,10 +307,24 @@ namespace Itinero.Optimization
         /// </summary>
         public static Result<Route> TryCalculateSTSP(this RouterBase router, Profile profile, Coordinate[] locations, float max, int first = 0, int? last = null)
         {
+            return router.TryCalculateSTSP(profile, locations, null, max, first, last);
+        }
+
+        /// <summary>
+        /// Calculates STSP.
+        /// </summary>
+        public static Result<Route> TryCalculateSTSP(this RouterBase router, Profile profile, List<RouterPoint> locations, float max, int first = 0, int? last = null)
+        {
+            return router.TryCalculateSTSP(profile, null, locations, max, first, last);
+        }
+
+        static Result<Route> TryCalculateSTSP(this RouterBase router, Profile profile, Coordinate[] visits, List<RouterPoint> locations, float max, int first, int? last)
+        {
             // build model.
             var model = new Model()
             {
-                Visits = locations,
+                Visits = visits,
+                Locations = locations,
                 VehiclePool = new Models.Vehicles.VehiclePool()
                 {
                     Vehicles = new Models.Vehicles.Vehicle[] 
@@ -265,12 +365,34 @@ namespace Itinero.Optimization
         /// <summary>
         /// Calculates STSP.
         /// </summary>
+        public static Route CalculateSTSP(this RouterBase router, Profile profile, List<RouterPoint> locations, float max, int first = 0, int? last = null)
+        {
+            return router.TryCalculateSTSP(profile, locations, max, first, last).Value;
+        }
+
+        /// <summary>
+        /// Calculates STSP.
+        /// </summary>
         public static Result<Route> TryCalculateSTSPDirected(this Router router, Profile profile, Coordinate[] locations, float turnPenaltyInSeconds, float max, int first = 0, int? last = null)
+        {
+            return router.TryCalculateSTSPDirected(profile, locations, null, turnPenaltyInSeconds, max, first, last);
+        }
+
+        /// <summary>
+        /// Calculates STSP.
+        /// </summary>
+        public static Result<Route> TryCalculateSTSPDirected(this Router router, Profile profile, List<RouterPoint> locations, float turnPenaltyInSeconds, float max, int first = 0, int? last = null)
+        {
+            return router.TryCalculateSTSPDirected(profile, null, locations, turnPenaltyInSeconds, max, first, last);
+        }
+
+        static Result<Route> TryCalculateSTSPDirected(this Router router, Profile profile, Coordinate[] visits, List<RouterPoint> locations, float turnPenaltyInSeconds, float max, int first, int? last)
         {
             // build model.
             var model = new Model()
             {
-                Visits = locations,
+                Visits = visits,
+                Locations = locations,
                 VehiclePool = new Models.Vehicles.VehiclePool()
                 {
                     Vehicles = new Models.Vehicles.Vehicle[] 
@@ -305,6 +427,14 @@ namespace Itinero.Optimization
         /// Calculates STSP.
         /// </summary>
         public static Route CalculateSTSPDirected(this Router router, Profile profile, Coordinate[] locations, float turnPenaltyInSeconds, float max, int first = 0, int? last = null)
+        {
+            return router.TryCalculateSTSPDirected(profile, locations, turnPenaltyInSeconds, max, first, last).Value;
+        }
+
+        /// <summary>
+        /// Calculates STSP.
+        /// </summary>
+        public static Route CalculateSTSPDirected(this Router router, Profile profile, List<RouterPoint> locations, float turnPenaltyInSeconds, float max, int first = 0, int? last = null)
         {
             return router.TryCalculateSTSPDirected(profile, locations, turnPenaltyInSeconds, max, first, last).Value;
         }


### PR DESCRIPTION
Aligns optimization extensions with routing extensions, both now allow using pre-resolved routerpoints.

This needs https://github.com/itinero/routing/pull/205 to build / work properly so not ready to merge.
There are no tests yet as I wanted some feedback first (+ I had some issues with the tests locally)